### PR TITLE
PROD-1286 passing through a date as the onChange value wasn't being updated.

### DIFF
--- a/src/DateTimeRange.jsx
+++ b/src/DateTimeRange.jsx
@@ -49,8 +49,8 @@ var DateTimeRange = React.createClass({
     };
   },
 
-  assumedEndDate: function() {
-    var endDate = new Date(this.props.start);
+  assumedEndDate: function(newDate) {
+    var endDate = new Date(newDate || this.props.start);
     endDate.setDate(endDate.getDate() + this.props.duration);
     return endDate;
   },
@@ -71,7 +71,7 @@ var DateTimeRange = React.createClass({
       if (child === startAndEnd.start) {
         return React.cloneElement(child, {
           onChange: function(newDate) {
-            self.props.onChange(newDate, self.props.end);
+            self.props.onChange(newDate, self.assumedEndDate(newDate));
           },
           value: self.props.start
         });

--- a/test/testDateTimeRange.jsx
+++ b/test/testDateTimeRange.jsx
@@ -245,7 +245,7 @@ describe('DateTimeRange', function() {
         handler = sinon.stub();
         props = {
           onChange: handler,
-          start:new Date(2015, 5, 6),
+          start: new Date(2015, 5, 6),
           end: new Date(2015, 5, 21, 16, 30, 0, 0)
         };
 

--- a/test/testDateTimeRange.jsx
+++ b/test/testDateTimeRange.jsx
@@ -239,12 +239,18 @@ describe('DateTimeRange', function() {
     });
 
     context('with an end date', function() {
-      var handler, changeStartDate, changeEndDate;
+      var handler, changeStartDate, changeEndDate, props;
 
       beforeEach(function() {
         handler = sinon.stub();
+        props = {
+          onChange: handler,
+          start:new Date(2015, 5, 6),
+          end: new Date(2015, 5, 21, 16, 30, 0, 0)
+        };
+
         var doc = TestUtils.renderIntoDocument(
-          <DateTimeRange onChange={handler} start={new Date(2015, 5, 6)} end={new Date(2015, 5, 20)}>
+          <DateTimeRange {...props}>
             <DateTimeGroup />
             <DateTimeGroup />
           </DateTimeRange>
@@ -260,7 +266,7 @@ describe('DateTimeRange', function() {
         it('emits up the changed start date and the passed in end date', function() {
           changeStartDate(new Date(2015, 5, 11, 16, 30, 0, 0));
 
-          sinon.assert.calledWith(handler, new Date(2015, 5, 11, 16, 30, 0, 0), new Date(2015, 5, 21, 16, 30, 0));
+          sinon.assert.calledWith(handler, new Date(2015, 5, 11, 16, 30, 0, 0), props.end);
         });
       });
 
@@ -268,7 +274,7 @@ describe('DateTimeRange', function() {
         it('emits up the passed in start date and the changed end date', function() {
           changeEndDate(new Date(2015, 5, 22, 16, 30, 0, 0));
 
-          sinon.assert.calledWith(handler, new Date(2015, 5, 6), new Date(2015, 5, 22, 16, 30, 0, 0));
+          sinon.assert.calledWith(handler, props.start, new Date(2015, 5, 22, 16, 30, 0, 0));
         });
       });
     });

--- a/test/testDateTimeRange.jsx
+++ b/test/testDateTimeRange.jsx
@@ -222,10 +222,10 @@ describe('DateTimeRange', function() {
       });
 
       context('when you change the start date', function() {
-        it('emits up the changed start date but no end date', function() {
+        it('emits up the changed start date and end date', function() {
           changeStartDate(new Date(2015, 5, 6, 16, 30, 0, 0));
 
-          sinon.assert.calledWith(handler, new Date(2015, 5, 6, 16, 30, 0, 0), undefined);
+          sinon.assert.calledWith(handler, new Date(2015, 5, 6, 16, 30, 0, 0), new Date(2015, 5, 16, 16, 30, 0, 0));
         });
       });
 
@@ -260,7 +260,7 @@ describe('DateTimeRange', function() {
         it('emits up the changed start date and the passed in end date', function() {
           changeStartDate(new Date(2015, 5, 11, 16, 30, 0, 0));
 
-          sinon.assert.calledWith(handler, new Date(2015, 5, 11, 16, 30, 0, 0), new Date(2015, 5, 20));
+          sinon.assert.calledWith(handler, new Date(2015, 5, 11, 16, 30, 0, 0), new Date(2015, 5, 21, 16, 30, 0));
         });
       });
 


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This test passes through a date to choose if we have selected one if not picks the start date.
#### What tests does this PR have?

Unit tests
#### How can this be tested?

Clone the repository
Go to my branch test-fix
Run npm start
Go to http://localhost:3000/example.html
Open console make sure get no errors while doing the following:
•Make sure when you change the start date the end date is 6 days forward.
•Click the second date field and make sure cant go before the start date.
•Make sure can still change times to what you need.

Example of the above: http://recordit.co/SQlrpioEfY
#### Screenshots / Screencast

Same as the above: http://recordit.co/SQlrpioEfY
#### What gif best describes how you feel about this work?

![](http://tclhost.com/mr0Pzal.gif)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** *
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
