### PR TITLE
PROD-1890 Fix for Changing Pickup Time Updates Dropoff Date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 install:
   - npm install npm@2
   - ./node_modules/.bin/npm install
-  - cd node_modules/react-date-time-group && npm run prepublish && cd -
 node_js:
   - "0.12"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-range",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "dist/DateTimeRange.js",
   "directories": {

--- a/src/DateTimeRange.jsx
+++ b/src/DateTimeRange.jsx
@@ -18,6 +18,13 @@ var DateTimeRange = React.createClass({
     };
   },
 
+  getInitialState: function() {
+    return {
+      overrideEndDate: (this.props.end === undefined ? false : true),
+      endDateHasChanged: false
+    }
+  },
+
   // Could this be made smarter? ie, detect components nested inside a <div>
   // inside this component, accept components based on an interface rather
   // than being of a certain type?
@@ -49,8 +56,16 @@ var DateTimeRange = React.createClass({
     };
   },
 
-  assumedEndDate: function(newDate) {
-    var endDate = new Date(newDate || this.props.start);
+  getEndDate: function(startDate) {
+    startDate = startDate || this.props.start;
+    if ((!this.state.overrideEndDate && !this.state.endDateHasChanged) || startDate > this.props.end) {
+      return this.assumedEndDate(startDate);
+    }
+    return this.props.end;
+  },
+
+  assumedEndDate: function(startDate) {
+    var endDate = new Date(startDate);
     endDate.setDate(endDate.getDate() + this.props.duration);
     return endDate;
   },
@@ -71,7 +86,7 @@ var DateTimeRange = React.createClass({
       if (child === startAndEnd.start) {
         return React.cloneElement(child, {
           onChange: function(newDate) {
-            self.props.onChange(newDate, self.assumedEndDate(newDate));
+            self.props.onChange(newDate, self.getEndDate(newDate));
           },
           value: self.props.start
         });
@@ -81,8 +96,11 @@ var DateTimeRange = React.createClass({
         return React.cloneElement(child, {
           onChange: function(newDate) {
             self.props.onChange(self.props.start, newDate);
+            self.setState({
+              endDateHasChanged: true
+            });
           },
-          value: ( self.props.start > self.props.end || self.props.end === undefined ) ? self.assumedEndDate() : self.props.end,
+          value: self.getEndDate(),
           dateStart: self.earliestDate(self.props.start, child.props.dateStart)
         });
       }

--- a/src/DateTimeRange.jsx
+++ b/src/DateTimeRange.jsx
@@ -20,8 +20,7 @@ var DateTimeRange = React.createClass({
 
   getInitialState: function() {
     return {
-      overrideEndDate: !(this.props.end === undefined),
-      endDateHasChanged: false
+      endDateShouldMoveAutomatically: (this.props.end === undefined)
     };
   },
 
@@ -58,7 +57,7 @@ var DateTimeRange = React.createClass({
 
   getEndDate: function(startDate) {
     startDate = startDate || this.props.start;
-    if ((!this.state.overrideEndDate && !this.state.endDateHasChanged) || startDate > this.props.end) {
+    if (this.state.endDateShouldMoveAutomatically || startDate > this.props.end) {
       return this.assumedEndDate(startDate);
     }
     return this.props.end;
@@ -97,7 +96,7 @@ var DateTimeRange = React.createClass({
           onChange: function(newDate) {
             self.props.onChange(self.props.start, newDate);
             self.setState({
-              endDateHasChanged: true
+              endDateShouldMoveAutomatically: false
             });
           },
           value: self.getEndDate(),

--- a/src/DateTimeRange.jsx
+++ b/src/DateTimeRange.jsx
@@ -20,9 +20,9 @@ var DateTimeRange = React.createClass({
 
   getInitialState: function() {
     return {
-      overrideEndDate: (this.props.end === undefined ? false : true),
+      overrideEndDate: !(this.props.end === undefined),
       endDateHasChanged: false
-    }
+    };
   },
 
   // Could this be made smarter? ie, detect components nested inside a <div>


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
The issue with the `<DateTimeRange>` React component is that if the **Start Date** is changed, the **End Date** is also always automatically changed (based on the **Start Date** and the duration period) no matter if the **End Date** was manually changed before that. This is confusing since you don't expect the **End Date** do be changed once you've manually set it to a specific date.

This PR fixes the issue with changing the behaviour like so: the **Start Date** should change the **End Date** only if the **End Date** hasn't been manually changed or if the new **Start Date** is past the current **End Date**.

#### How can this be tested?
If you don't have this repo locally you should go through these steps first:
1. Clone the repo: `git@github.com:holidayextras/react-date-time-range.git`
2. Go inside the repo: `cd react-date-time-range`
3. Install all dependencies: `npm install`

To test changes in this branch:
1. Checkout this branch `git checkout PROD-1890`
2. Open the example page: `npm start` and open the [Example page](http://localhost:3000/example.html) in the browser.
3. There are two examples on the [Example page](http://localhost:3000/example.html) (see screenshot for how it looks).
- First example (**Basic example**) - Make sure that it follows the behaviour described above (on the `master` branch changing the **Start Date** always leads to automatically changing the **End Date**).
- Second example (**Overriding settings**) - Make sure that changing the **Start Date** does not lead to automatic change of the **End Date**.

#### Screenshots / Screencast
![The example page](https://cldup.com/6vd_GgezIT.png)
---

**Reviewer**
- [ ] :+1:
- [ ] I don't think this PR needs any additional reviewers

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).

---
